### PR TITLE
Make Var creation a token-based singleton factory

### DIFF
--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -8,6 +8,8 @@ def test_isvar():
 
 def test_var():
     assert var(1) == var(1)
+    one_lv = var(1)
+    assert var(1) is one_lv
     assert var() != var()
 
 

--- a/unification/variable.py
+++ b/unification/variable.py
@@ -1,6 +1,9 @@
+import weakref
+
 from contextlib import contextmanager, suppress
 
 from .dispatch import dispatch
+
 
 _global_logic_variables = set()
 _glv = _global_logic_variables
@@ -9,6 +12,8 @@ _glv = _global_logic_variables
 class Var(object):
     """A logic variable type."""
 
+    __slots__ = ("token", "__weakref__")
+    _refs = weakref.WeakValueDictionary()
     _id = 1
 
     def __new__(cls, *token):
@@ -18,8 +23,13 @@ class Var(object):
         elif len(token) == 1:
             token = token[0]
 
-        obj = object.__new__(cls)
-        obj.token = token
+        obj = Var._refs.get(token, None)
+
+        if obj is None:
+            obj = object.__new__(cls)
+            obj.token = token
+            Var._refs[token] = obj
+
         return obj
 
     def __str__(self):


### PR DESCRIPTION
`Var` objects are cached in a class-scope `WeakValueDictionary` using `Var.token` as the keys/unique identifiers.  

This change makes it possible to use weak references to logic variables while preserving their global, token-based equality.  More specifically, `kanren` states and `unification` maps can consist of `WeakKeyDictionary`s and automatically remove temporary logic variables (e.g. the kind that are generated by `kanren` goals and never referenced again).