### PR TITLE
Improve type dispatching

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,7 @@
-from unification.core import reify, unify
+from types import MappingProxyType
+
 from unification import var
+from unification.core import reify, unify
 
 
 def test_reify():
@@ -10,6 +12,7 @@ def test_reify():
     assert reify((1, y), s) == (1, 2)
     assert reify((1, (x, (y, 2))), s) == (1, (1, (2, 2)))
     assert reify(z, s) == (1, 2)
+    assert reify(z, MappingProxyType(s)) == (1, 2)
 
 
 def test_reify_dict():
@@ -39,6 +42,12 @@ def test_unify():
     assert unify(1, 2, {}) == False
     assert unify(var(1), 2, {}) == {var(1): 2}
     assert unify(2, var(1), {}) == {var(1): 2}
+    assert unify(2, var(1), MappingProxyType({})) == {var(1): 2}
+
+
+def test_iter():
+    assert unify([1], (1,)) is False
+    assert unify((i for i in [1, 2]), [1, 2]) is False
 
 
 def test_unify_seq():

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -54,7 +54,8 @@ def test_complex():
     assert d(2, 1) == 3
     assert d(10, 10) == 100
     assert d(10, (10, 10)) == (10, (10, 10))
-    assert raises(NotImplementedError, lambda: d(1, 2))
+    with raises(NotImplementedError):
+        d(1, 2)
 
 
 def test_dict():
@@ -70,7 +71,6 @@ def test_ordering():
     x = var("x")
     y = var("y")
     o = ordering([(1,), (x,), (2,), (y,), (x, x), (1, x), (x, 1), (1, 2)])
-    print("Ordering:", o)
 
     for a, b in zip(o, o[1:]):
         assert supercedes(a, b) or not supercedes(b, a)
@@ -79,7 +79,8 @@ def test_ordering():
 def test_raises_error():
     d = Dispatcher("d")
 
-    assert raises(NotImplementedError, lambda: d(1, 2, 3))
+    with raises(NotImplementedError):
+        d(1, 2, 3)
 
 
 def test_register():


### PR DESCRIPTION
Dispatch on `collections.abc.Mapping` instead of `dict`, so that more map types can make use of the core dispatch implementations.  Also, add a type check and correct the length check for `Iterator` types.  Without the latter fix, `unify([1], (1,))` would succeed, which conflicts with the definition of unification between ground objects (i.e. it reduces to an equality check).