### PR TITLE
Refactor logic variable class

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,7 +39,7 @@ def test_reify_complex():
 
 def test_unify():
     assert unify(1, 1, {}) == {}
-    assert unify(1, 2, {}) == False
+    assert unify(1, 2, {}) is False
     assert unify(var(1), 2, {}) == {var(1): 2}
     assert unify(2, var(1), {}) == {var(1): 2}
     assert unify(2, var(1), MappingProxyType({})) == {var(1): 2}

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -11,6 +11,7 @@ def test_var():
     one_lv = var(1)
     assert var(1) is one_lv
     assert var() != var()
+    assert var(prefix="a") != var(prefix="a")
 
 
 def test_var_inputs():

--- a/unification/variable.py
+++ b/unification/variable.py
@@ -1,15 +1,20 @@
 import weakref
 
+from abc import ABCMeta
 from contextlib import contextmanager, suppress
-
-from .dispatch import dispatch
 
 
 _global_logic_variables = set()
 _glv = _global_logic_variables
 
 
-class Var(object):
+class LVarType(ABCMeta):
+    def __instancecheck__(self, o):
+        with suppress(TypeError):
+            return issubclass(type(o), LVarType) or o in _glv
+
+
+class Var(metaclass=LVarType):
     """A logic variable type.
 
     Fresh logic variables will unify with anything:
@@ -73,15 +78,8 @@ def vars(n, **kwargs):
     return [var(**kwargs) for i in range(n)]
 
 
-@dispatch(Var)
-def isvar(v):
-    return True
-
-
-@dispatch(object)
 def isvar(o):
-    with suppress(TypeError):
-        return o in _glv
+    return isinstance(o, Var)
 
 
 @contextmanager


### PR DESCRIPTION
Remove unnecessary use of `multipledispatch` for logic variable instance checking and make the built-in `isinstance(x, Var)` idiom compatible with `variables` context manager.  Now, `isinstance` can be used instead of `isvar` and built-in features like `isinstance(x, (Var, ...))`  will work.

Also, minor refactoring and a new prefix feature that makes it easier to tell apart fresh logic variables in `str`/`repr` output:
```python
>>> vars(2, prefix='blah')
[~blah_1, ~blah_2]
```